### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/diatche/jest-runner-serial/issues"
   },
   "homepage": "https://github.com/diatche/jest-runner-serial#readme",
+  "peerDependencies": {
+    "jest-runner": ">24.8.0"
+  },
   "devDependencies": {
     "jest-runner": ">24.8.0"
   }


### PR DESCRIPTION
Make jest-runner peer dependency to allow users specify needed version. Also it will show proper warning if user has misconfigured his deps and has no jest-runner for some reason,