### PR TITLE
fix: error for jest 27

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const TestRunner = require('jest-runner')
+const TestRunner = require('jest-runner').default || require('jest-runner')
 
 class SerialRunner extends TestRunner {
   constructor(...attr) {


### PR DESCRIPTION
It fixes "TypeError: Class extends value #<Object> is not a constructor or null" error for jest 27 runner.